### PR TITLE
calling api from alternate node

### DIFF
--- a/account.go
+++ b/account.go
@@ -115,8 +115,7 @@ func (h *HiveRpcNode) GetAccount(accountNames []string) ([]AccountData, error) {
 		method: "condenser_api.get_accounts",
 		params: params,
 	}
-	endpoint := h.address
-	res, err := h.rpcExec(endpoint, query)
+	res, err := h.rpcExec(query)
 	if err != nil {
 		return nil, err
 	}

--- a/blockApi.go
+++ b/blockApi.go
@@ -195,7 +195,7 @@ func (h *HiveRpcNode) StreamBlocks() (<-chan Block, error) {
 
 	go func() {
 		dynProps := hrpcQuery{method: "condenser_api.get_dynamic_global_properties", params: []string{}}
-		res, err := h.rpcExec(h.address, dynProps)
+		res, err := h.rpcExec(dynProps)
 		if err != nil {
 			log.Fatalf("Failed to fetch dynamic global properties: %v", err)
 			close(blockChan)
@@ -234,8 +234,7 @@ func (h *HiveRpcNode) FetchVirtualOps(blockHeight int, onlyVirtual bool, Include
 	query := hrpcQuery{method: "account_history_api.get_ops_in_block", params: params}
 	queries := []hrpcQuery{query}
 
-	endpoint := h.address
-	res, err := h.rpcExecBatchFast(endpoint, queries)
+	res, err := h.rpcExecBatchFast(queries)
 
 	if err != nil {
 		return nil, err
@@ -297,8 +296,7 @@ func (h *HiveRpcNode) fetchBlockInRange(startBlock, count int) ([]Block, error) 
 	query := hrpcQuery{method: "block_api.get_block_range", params: params}
 	queries := []hrpcQuery{query}
 
-	endpoint := h.address
-	res, err := h.rpcExecBatchFast(endpoint, queries)
+	res, err := h.rpcExecBatchFast(queries)
 	if err != nil {
 		return nil, err
 	}
@@ -337,8 +335,7 @@ func (h *HiveRpcNode) fetchBlock(params []getBlockQueryParams) ([]Block, error) 
 		queries = append(queries, query)
 	}
 
-	endpoint := h.address
-	res, err := h.rpcExecBatchFast(endpoint, queries)
+	res, err := h.rpcExecBatchFast(queries)
 	if err != nil {
 		return nil, err
 	}

--- a/blockApi_test.go
+++ b/blockApi_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestVirtualOps(t *testing.T) {
-	rpc := NewHiveRpc([]string{"https://invalid.com","https://api.hive.blog"})
+	rpc := NewHiveRpc([]string{"https://invalid.com", "https://api.hive.blog"}, true)
 	virtualOps, err := rpc.FetchVirtualOps(88386873, true, false)
 
 	if err != nil {

--- a/blockApi_test.go
+++ b/blockApi_test.go
@@ -6,11 +6,11 @@ import (
 )
 
 func TestVirtualOps(t *testing.T) {
-	rpc := NewHiveRpc("https://api.hive.blog")
+	rpc := NewHiveRpc([]string{"https://invalid.com","https://api.hive.blog"})
 	virtualOps, err := rpc.FetchVirtualOps(88386873, true, false)
 
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 	}
 	fmt.Println(virtualOps)
 }

--- a/blockApi_test.go
+++ b/blockApi_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestVirtualOps(t *testing.T) {
-	rpc := NewHiveRpc([]string{"https://invalid.com", "https://api.hive.blog"}, true)
+	rpc := NewHiveRpc([]string{"https://invalid.com", "https://api.hive.blog"})
 	virtualOps, err := rpc.FetchVirtualOps(88386873, true, false)
 
 	if err != nil {

--- a/broadcaster.go
+++ b/broadcaster.go
@@ -100,7 +100,7 @@ func (h *HiveRpcNode) Broadcast(ops []HiveOperation, wif *string) (string, error
 	params = append(params, tx)
 	if !h.NoBroadcast {
 		q := hrpcQuery{"condenser_api.broadcast_transaction", params}
-		res, err := h.rpcExec(h.address, q)
+		res, err := h.rpcExec(q)
 		if err != nil {
 			return string(res), err
 		}
@@ -119,7 +119,7 @@ func (h *HiveRpcNode) BroadcastRaw(tx HiveTransaction) (string, error) {
 	params = append(params, tx)
 	if !h.NoBroadcast {
 		q := hrpcQuery{"condenser_api.broadcast_transaction", params}
-		res, err := h.rpcExec(h.address, q)
+		res, err := h.rpcExec(q)
 		if err != nil {
 			return string(res), err
 		}

--- a/hrpcclient.go
+++ b/hrpcclient.go
@@ -2,16 +2,25 @@ package hivego
 
 import (
 	"errors"
-	"strconv"
+	"sync"
 
 	"github.com/cfoxon/jsonrpc2client"
 )
 
+type NodeStats struct {
+	successCount int
+	failureCount int
+	rollingAvg   float64
+}
+
 type HiveRpcNode struct {
-	address     string
-	MaxConn     int
-	MaxBatch    int
-	NoBroadcast bool
+	addresses      []string
+	currentIndex   int
+	nodeStats      []NodeStats
+	mutex          sync.RWMutex
+	MaxConn        int
+	MaxBatch       int
+	NoBroadcast    bool
 }
 
 type globalProps struct {
@@ -25,57 +34,125 @@ type hrpcQuery struct {
 	params interface{}
 }
 
-func NewHiveRpc(addr string) *HiveRpcNode {
-	return NewHiveRpcWithOpts(addr, 1, 1)
+func NewHiveRpc(addrs []string) *HiveRpcNode {
+	return NewHiveRpcWithOpts(addrs, 1, 1)
 }
 
-func NewHiveRpcWithOpts(addr string, maxConn int, maxBatch int) *HiveRpcNode {
-	return &HiveRpcNode{address: addr,
-		MaxConn:  maxConn,
-		MaxBatch: maxBatch,
+func NewHiveRpcWithOpts(addrs []string, maxConn int, maxBatch int) *HiveRpcNode {
+	nodeStats := make([]NodeStats, len(addrs))
+	return &HiveRpcNode{
+		addresses:    addrs,
+		currentIndex: 0,
+		nodeStats:    nodeStats,
+		MaxConn:      maxConn,
+		MaxBatch:     maxBatch,
 	}
 }
 
 func (h *HiveRpcNode) GetDynamicGlobalProps() ([]byte, error) {
 	q := hrpcQuery{method: "condenser_api.get_dynamic_global_properties", params: []string{}}
-	res, err := h.rpcExec(h.address, q)
+	res, err := h.rpcExec(q)
 	if err != nil {
 		return nil, err
 	}
 	return res, nil
 }
 
-func (h *HiveRpcNode) rpcExec(endpoint string, query hrpcQuery) ([]byte, error) {
-	rpcClient := jsonrpc2client.NewClientWithOpts(endpoint, h.MaxConn, h.MaxBatch)
-	jr2query := &jsonrpc2client.RpcRequest{Method: query.method, JsonRpc: "2.0", Id: 1, Params: query.params}
-	resp, err := rpcClient.CallRaw(jr2query)
-	if err != nil {
-		return nil, err
+func (h *HiveRpcNode) rpcExec(query hrpcQuery) ([]byte, error) {
+	h.mutex.Lock()
+	defer h.mutex.Unlock()
+
+	numNodes := len(h.addresses)
+	for i := 0; i < numNodes; i++ {
+		index := (h.currentIndex + i) % numNodes
+		endpoint := h.addresses[index]
+
+		rpcClient := jsonrpc2client.NewClientWithOpts(endpoint, h.MaxConn, h.MaxBatch)
+		jr2query := &jsonrpc2client.RpcRequest{Method: query.method, JsonRpc: "2.0", Id: 1, Params: query.params}
+		resp, err := rpcClient.CallRaw(jr2query)
+		if err != nil {
+			h.nodeStats[index].failureCount++
+			h.updateRollingAvg(index)
+			continue
+		}
+
+		if resp.Error != nil {
+			h.nodeStats[index].failureCount++
+			h.updateRollingAvg(index)
+			continue
+		}
+
+		// Check for bad data: if result is empty, consider it bad
+		if len(resp.Result) == 0 {
+			h.nodeStats[index].failureCount++
+			h.updateRollingAvg(index)
+			continue
+		}
+
+		// Success
+		h.nodeStats[index].successCount++
+		h.updateRollingAvg(index)
+		h.currentIndex = index // Set to last successful node
+		return resp.Result, nil
 	}
 
-	if resp.Error != nil {
-		return nil, errors.New(strconv.Itoa(resp.Error.Code) + "    " + resp.Error.Message)
-	}
-
-	return resp.Result, nil
+	return nil, errors.New("all API nodes failed")
 }
 
-func (h *HiveRpcNode) rpcExecBatchFast(endpoint string, queries []hrpcQuery) ([][]byte, error) {
-	rpcClient := jsonrpc2client.NewClientWithOpts(endpoint, h.MaxConn, h.MaxBatch)
+func (h *HiveRpcNode) updateRollingAvg(index int) {
+	total := h.nodeStats[index].successCount + h.nodeStats[index].failureCount
+	if total > 0 {
+		h.nodeStats[index].rollingAvg = float64(h.nodeStats[index].successCount) / float64(total)
+	}
+}
 
-	var jr2queries jsonrpc2client.RPCRequests
-	for i, query := range queries {
-		jr2query := &jsonrpc2client.RpcRequest{Method: query.method, JsonRpc: "2.0", Id: i, Params: query.params}
-		jr2queries = append(jr2queries, jr2query)
+func (h *HiveRpcNode) rpcExecBatchFast(queries []hrpcQuery) ([][]byte, error) {
+	h.mutex.Lock()
+	defer h.mutex.Unlock()
+
+	numNodes := len(h.addresses)
+	for i := 0; i < numNodes; i++ {
+		index := (h.currentIndex + i) % numNodes
+		endpoint := h.addresses[index]
+
+		rpcClient := jsonrpc2client.NewClientWithOpts(endpoint, h.MaxConn, h.MaxBatch)
+
+		var jr2queries jsonrpc2client.RPCRequests
+		for j, query := range queries {
+			jr2query := &jsonrpc2client.RpcRequest{Method: query.method, JsonRpc: "2.0", Id: j, Params: query.params}
+			jr2queries = append(jr2queries, jr2query)
+		}
+
+		resps, err := rpcClient.CallBatchFast(jr2queries)
+		if err != nil {
+			h.nodeStats[index].failureCount++
+			h.updateRollingAvg(index)
+			continue
+		}
+
+		// Check if any response has error or bad data
+		hasError := false
+		for _, respBytes := range resps {
+			if len(respBytes) == 0 {
+				hasError = true
+				break
+			}
+		}
+		if hasError {
+			h.nodeStats[index].failureCount++
+			h.updateRollingAvg(index)
+			continue
+		}
+
+		// Success
+		h.nodeStats[index].successCount++
+		h.updateRollingAvg(index)
+		h.currentIndex = index
+
+		var batchResult [][]byte
+		batchResult = append(batchResult, resps...)
+		return batchResult, nil
 	}
 
-	resps, err := rpcClient.CallBatchFast(jr2queries)
-	if err != nil {
-		return nil, err
-	}
-
-	var batchResult [][]byte
-	batchResult = append(batchResult, resps...)
-
-	return batchResult, nil
+	return nil, errors.New("all API nodes failed")
 }

--- a/hrpcclient.go
+++ b/hrpcclient.go
@@ -128,10 +128,8 @@ func (h *HiveRpcNode) logFailureCounts() {
 }
 
 func (h *HiveRpcNode) logSwitchingNode(currentIndex int, nextIndex int, numNodes int) {
-	if nextIndex < numNodes {
-		nextEndpoint := h.addresses[nextIndex]
-		log.Printf("DEBUG: Switching to node: %s (index %d)", nextEndpoint, nextIndex)
-	}
+	nextEndpoint := h.addresses[nextIndex]
+	log.Printf("DEBUG: Switching to node: %s (index %d)", nextEndpoint, nextIndex)
 }
 
 func (h *HiveRpcNode) rpcExecBatchFast(queries []hrpcQuery) ([][]byte, error) {

--- a/hrpcclient_test.go
+++ b/hrpcclient_test.go
@@ -1,0 +1,93 @@
+package hivego
+
+import (
+	"testing"
+)
+
+func TestFailoverWithMultipleNodes(t *testing.T) {
+	// Test with one good node and one bad node
+	// Using a real endpoint and an invalid one to simulate failure
+	addrs := []string{"https://api.hive.blog", "https://invalid.endpoint.com"}
+	rpc := NewHiveRpc(addrs)
+
+	// This should succeed on the first node
+	_, err := rpc.GetDynamicGlobalProps()
+	if err != nil {
+		t.Errorf("Expected success with failover, but got error: %v", err)
+	}
+
+	// Check that currentIndex is set to the successful node (index 0)
+	if rpc.currentIndex != 0 {
+		t.Errorf("Expected currentIndex to be 0 (last successful), got %d", rpc.currentIndex)
+	}
+
+	// Check stats: first node should have success count > 0
+	if rpc.nodeStats[0].successCount == 0 {
+		t.Errorf("Expected success count > 0 for first node, got %d", rpc.nodeStats[0].successCount)
+	}
+}
+
+func TestFailoverAllNodesFail(t *testing.T) {
+	// Test with all invalid nodes
+	addrs := []string{"https://invalid1.com", "https://invalid2.com"}
+	rpc := NewHiveRpc(addrs)
+
+	_, err := rpc.GetDynamicGlobalProps()
+	if err == nil {
+		t.Errorf("Expected failure when all nodes fail, but got success")
+	}
+
+	// Check that error message indicates all failed
+	expectedMsg := "all API nodes failed"
+	if err.Error() != expectedMsg {
+		t.Errorf("Expected error message '%s', got '%s'", expectedMsg, err.Error())
+	}
+}
+
+func TestRoundRobinPriority(t *testing.T) {
+	// Test that it starts from currentIndex and updates to last successful
+	addrs := []string{"https://invalid.com", "https://api.hive.blog"}
+	rpc := NewHiveRpc(addrs)
+
+	// First call should fail on invalid, succeed on second, set currentIndex to 1
+	_, err := rpc.GetDynamicGlobalProps()
+	if err != nil {
+		t.Errorf("Expected success, got error: %v", err)
+	}
+
+	if rpc.currentIndex != 1 {
+		t.Errorf("Expected currentIndex to be 1, got %d", rpc.currentIndex)
+	}
+
+	// Second call should start from index 1 (the last successful)
+	rpc.currentIndex = 0 // Reset to test
+	_, err = rpc.GetDynamicGlobalProps()
+	if err != nil {
+		t.Errorf("Expected success on second call, got error: %v", err)
+	}
+
+	// Should have tried invalid first (failure), then api.hive.blog (success)
+	if rpc.nodeStats[0].failureCount == 0 {
+		t.Errorf("Expected failure count > 0 for invalid node")
+	}
+	if rpc.nodeStats[1].successCount == 0 {
+		t.Errorf("Expected success count > 0 for valid node")
+	}
+}
+
+func TestRollingAverage(t *testing.T) {
+	addrs := []string{"https://api.hive.blog"}
+	rpc := NewHiveRpc(addrs)
+
+	// Make a successful call
+	_, err := rpc.GetDynamicGlobalProps()
+	if err != nil {
+		t.Errorf("Expected success, got error: %v", err)
+	}
+
+	// Rolling average should be 1.0 (1 success, 0 failures)
+	expectedAvg := 1.0
+	if rpc.nodeStats[0].rollingAvg != expectedAvg {
+		t.Errorf("Expected rolling average %f, got %f", expectedAvg, rpc.nodeStats[0].rollingAvg)
+	}
+}

--- a/hrpcclient_test.go
+++ b/hrpcclient_test.go
@@ -8,7 +8,7 @@ func TestFailoverWithMultipleNodes(t *testing.T) {
 	// Test with one good node and one bad node
 	// Using a real endpoint and an invalid one to simulate failure
 	addrs := []string{"https://api.hive.blog", "https://invalid.endpoint.com"}
-	rpc := NewHiveRpc(addrs)
+	rpc := NewHiveRpc(addrs, true)
 
 	// This should succeed on the first node
 	_, err := rpc.GetDynamicGlobalProps()
@@ -30,7 +30,7 @@ func TestFailoverWithMultipleNodes(t *testing.T) {
 func TestFailoverAllNodesFail(t *testing.T) {
 	// Test with all invalid nodes
 	addrs := []string{"https://invalid1.com", "https://invalid2.com"}
-	rpc := NewHiveRpc(addrs)
+	rpc := NewHiveRpc(addrs, true)
 
 	_, err := rpc.GetDynamicGlobalProps()
 	if err == nil {
@@ -47,7 +47,7 @@ func TestFailoverAllNodesFail(t *testing.T) {
 func TestRoundRobinPriority(t *testing.T) {
 	// Test that it starts from currentIndex and updates to last successful
 	addrs := []string{"https://invalid.com", "https://api.hive.blog"}
-	rpc := NewHiveRpc(addrs)
+	rpc := NewHiveRpc(addrs, true)
 
 	// First call should fail on invalid, succeed on second, set currentIndex to 1
 	_, err := rpc.GetDynamicGlobalProps()
@@ -77,7 +77,7 @@ func TestRoundRobinPriority(t *testing.T) {
 
 func TestRollingAverage(t *testing.T) {
 	addrs := []string{"https://api.hive.blog"}
-	rpc := NewHiveRpc(addrs)
+	rpc := NewHiveRpc(addrs, true)
 
 	// Make a successful call
 	_, err := rpc.GetDynamicGlobalProps()

--- a/hrpcclient_test.go
+++ b/hrpcclient_test.go
@@ -8,7 +8,7 @@ func TestFailoverWithMultipleNodes(t *testing.T) {
 	// Test with one good node and one bad node
 	// Using a real endpoint and an invalid one to simulate failure
 	addrs := []string{"https://api.hive.blog", "https://invalid.endpoint.com"}
-	rpc := NewHiveRpc(addrs, true)
+	rpc := NewHiveRpc(addrs)
 
 	// This should succeed on the first node
 	_, err := rpc.GetDynamicGlobalProps()
@@ -30,7 +30,7 @@ func TestFailoverWithMultipleNodes(t *testing.T) {
 func TestFailoverAllNodesFail(t *testing.T) {
 	// Test with all invalid nodes
 	addrs := []string{"https://invalid1.com", "https://invalid2.com"}
-	rpc := NewHiveRpc(addrs, true)
+	rpc := NewHiveRpc(addrs)
 
 	_, err := rpc.GetDynamicGlobalProps()
 	if err == nil {
@@ -47,7 +47,7 @@ func TestFailoverAllNodesFail(t *testing.T) {
 func TestRoundRobinPriority(t *testing.T) {
 	// Test that it starts from currentIndex and updates to last successful
 	addrs := []string{"https://invalid.com", "https://api.hive.blog"}
-	rpc := NewHiveRpc(addrs, true)
+	rpc := NewHiveRpc(addrs)
 
 	// First call should fail on invalid, succeed on second, set currentIndex to 1
 	_, err := rpc.GetDynamicGlobalProps()
@@ -77,7 +77,7 @@ func TestRoundRobinPriority(t *testing.T) {
 
 func TestRollingAverage(t *testing.T) {
 	addrs := []string{"https://api.hive.blog"}
-	rpc := NewHiveRpc(addrs, true)
+	rpc := NewHiveRpc(addrs)
 
 	// Make a successful call
 	_, err := rpc.GetDynamicGlobalProps()

--- a/logging_debug.go
+++ b/logging_debug.go
@@ -1,0 +1,7 @@
+//go:build debug
+
+package hivego
+
+// enableLogging is true when built with the "debug" build tag
+// This enables logging for development purposes
+const enableLogging = true

--- a/logging_release.go
+++ b/logging_release.go
@@ -1,0 +1,7 @@
+//go:build !debug
+
+package hivego
+
+// enableLogging is false when built without the "debug" build tag
+// This disables logging for production builds
+const enableLogging = false

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ At this time, there are only a few functions from the client. More will be added
 create a client:
 ```
 addrs := []string{"https://api.hive.blog", "https://api.myHiveBlockchainNode.com"}
-hrpc := hivego.NewHiveRpc(addrs)
+hrpc := hivego.NewHiveRpc(addrs, true) // enableLogging: true to see failure logs
 ```
 
 submit a custom json tx:

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,8 @@ At this time, there are only a few functions from the client. More will be added
 ### Example usage:
 create a client:
 ```
-hrpc := hivego.NewHiveRpc("https://api.myHiveBlockchainNode.com")
+addrs := []string{"https://api.hive.blog", "https://api.myHiveBlockchainNode.com"}
+hrpc := hivego.NewHiveRpc(addrs)
 ```
 
 submit a custom json tx:

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,11 @@ At this time, there are only a few functions from the client. More will be added
 create a client:
 ```
 addrs := []string{"https://api.hive.blog", "https://api.myHiveBlockchainNode.com"}
-hrpc := hivego.NewHiveRpc(addrs, true) // enableLogging: true to see failure logs
+hrpc := hivego.NewHiveRpc(addrs)
+
+// Note: Logging is controlled by build tags:
+//   - Development: go build -tags debug
+//   - Production: go build (default, no logging)
 ```
 
 submit a custom json tx:

--- a/transaction.go
+++ b/transaction.go
@@ -7,8 +7,7 @@ type TransactionQueryParams struct {
 
 func (h *HiveRpcNode) GetTransaction(txId string, includeReversible bool) ([]byte, error) {
 	var query = hrpcQuery{method: "account_history_api.get_transaction", params: TransactionQueryParams{TransactionId: txId, IncludeReversible: includeReversible}}
-	endpoint := h.address
-	res, err := h.rpcExec(endpoint, query)
+	res, err := h.rpcExec(query)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Goal

Add multi-node support to the RPC client so it can automatically switch to alternate Hive RPC endpoints when one fails.

## How was it done?

### Address the Goal

- The client was updated to manage multiple RPC endpoints.
- Requests now start from the last successful endpoint and fall back to others when needed.
- All RPC actions now route through this failover logic without requiring a manually supplied endpoint.

### Implementation details (without code)

- An array of endpoint URLs is stored inside the client.
- An integer index tracks which endpoint last succeeded.
- Each endpoint maintains simple stats such as success and failure counts.
- A request is marked as failed on network errors, HTTP issues, parsing errors, RPC errors, or empty results.
- On failure, the next endpoint in the array is tried; on success, stats are updated and the index is set to the successful endpoint.
- This process follows a round-robin pattern until a valid response is received or all endpoints fail.