### PR TITLE
Chain ID config

### DIFF
--- a/chainid_test.go
+++ b/chainid_test.go
@@ -8,10 +8,7 @@ import (
 func TestCustomChainID(t *testing.T) {
 	// Test that custom chain ID is used when provided
 	tx := getTestVoteTx()
-
-	// Set a custom chain ID
 	customChainID := "1234567800000000000000000000000000000000000000000000000000000000"
-	tx.ChainID = customChainID
 
 	// Test signing with custom chain ID
 	message, err := SerializeTx(tx)
@@ -27,7 +24,7 @@ func TestCustomChainID(t *testing.T) {
 	}
 
 	// Sign with custom chain ID
-	sig, err := tx.Sign(*keyPair)
+	sig, err := tx.Sign(*keyPair, customChainID)
 	if err != nil {
 		t.Fatal("Failed to sign transaction:", err)
 	}
@@ -38,8 +35,7 @@ func TestCustomChainID(t *testing.T) {
 	}
 
 	// Test that the signature is different from default chain ID signature
-	txDefault := getTestVoteTx() // No custom chain ID
-	sigDefault, err := txDefault.Sign(*keyPair)
+	sigDefault, err := tx.Sign(*keyPair)
 	if err != nil {
 		t.Fatal("Failed to sign transaction with default chain ID:", err)
 	}

--- a/chainid_test.go
+++ b/chainid_test.go
@@ -1,0 +1,72 @@
+package hivego
+
+import (
+	"encoding/hex"
+	"testing"
+)
+
+func TestCustomChainID(t *testing.T) {
+	// Test that custom chain ID is used when provided
+	tx := getTestVoteTx()
+
+	// Set a custom chain ID
+	customChainID := "1234567800000000000000000000000000000000000000000000000000000000"
+	tx.ChainID = customChainID
+
+	// Test signing with custom chain ID
+	message, err := SerializeTx(tx)
+	if err != nil {
+		t.Fatal("Failed to serialize transaction:", err)
+	}
+
+	// Create a test key pair
+	wif := "5JuMt237G3m3BaT7zH4YdoycUtbw4AEPy6DLdCrKAnFGAtXyQ1W"
+	keyPair, err := KeyPairFromWif(wif)
+	if err != nil {
+		t.Fatal("Failed to create key pair:", err)
+	}
+
+	// Sign with custom chain ID
+	sig, err := tx.Sign(*keyPair)
+	if err != nil {
+		t.Fatal("Failed to sign transaction:", err)
+	}
+
+	// Verify signature is not empty
+	if sig == "" {
+		t.Error("Signature should not be empty")
+	}
+
+	// Test that the signature is different from default chain ID signature
+	txDefault := getTestVoteTx() // No custom chain ID
+	sigDefault, err := txDefault.Sign(*keyPair)
+	if err != nil {
+		t.Fatal("Failed to sign transaction with default chain ID:", err)
+	}
+
+	// Signatures should be different
+	if sig == sigDefault {
+		t.Error("Signatures with custom and default chain IDs should be different")
+	}
+
+	// Test HashTxForSig with custom chain ID
+	digestCustom := HashTxForSig(message, customChainID)
+	digestDefault := HashTxForSig(message) // Uses default chain ID
+
+	// Digests should be different
+	if hex.EncodeToString(digestCustom) == hex.EncodeToString(digestDefault) {
+		t.Error("Digests with custom and default chain IDs should be different")
+	}
+}
+
+func TestHiveRpcNodeChainID(t *testing.T) {
+	// Test that HiveRpcNode uses its ChainID property
+	node := NewHiveRpcWithOpts([]string{"https://api.hive.blog"}, 1, 1)
+	customChainID := "fedcba9800000000000000000000000000000000000000000000000000000000"
+	node.ChainID = customChainID
+
+	// The node should have the custom chain ID
+	if node.ChainID != customChainID {
+		t.Errorf("Expected node ChainID to be %s, got %s", customChainID, node.ChainID)
+	}
+}

--- a/hrpcclient.go
+++ b/hrpcclient.go
@@ -22,6 +22,7 @@ type HiveRpcNode struct {
 	MaxConn      int
 	MaxBatch     int
 	NoBroadcast  bool
+	ChainID      string
 }
 
 type globalProps struct {

--- a/hrpcclient_test.go
+++ b/hrpcclient_test.go
@@ -37,10 +37,10 @@ func TestFailoverAllNodesFail(t *testing.T) {
 		t.Errorf("Expected failure when all nodes fail, but got success")
 	}
 
-	// Check that error message indicates all failed
-	expectedMsg := "all API nodes failed"
-	if err.Error() != expectedMsg {
-		t.Errorf("Expected error message '%s', got '%s'", expectedMsg, err.Error())
+	// Check that an error occurred (the actual error message should now be specific)
+	// This verifies that the function returns the actual error instead of generic message
+	if err.Error() == "all API nodes failed" {
+		t.Errorf("Expected specific error message, but got generic 'all API nodes failed'")
 	}
 }
 

--- a/serializer.go
+++ b/serializer.go
@@ -81,12 +81,20 @@ func appendVAsset(asset string, b *bytes.Buffer) error {
 		precision = 6
 	}
 
-	// Convert to legacy symbol names for compatibility
+	var nai uint32
 	switch symbol {
 	case "HIVE":
-		symbol = "STEEM"
+		fallthrough
+	case "TESTS":
+		nai = ((99999999 + 2) << 5) | 3
 	case "HBD":
-		symbol = "SBD"
+		fallthrough
+	case "TBD":
+		nai = ((99999999 + 1) << 5) | 3
+	case "VESTS":
+		nai = ((99999999 + 3) << 5) | 6
+	default:
+		return errors.New("invalid asset symbol")
 	}
 
 	// Handle decimal parsing without floating points
@@ -119,17 +127,10 @@ func appendVAsset(asset string, b *bytes.Buffer) error {
 		return err
 	}
 
-	// write the precision
-	b.WriteByte(byte(precision))
-
-	// write the symbol NUL padded to 8 bits
-	for i := 0; i < 7; i++ {
-		if i < len(symbol) {
-			b.WriteByte(symbol[i])
-		} else {
-			b.WriteByte(byte(0))
-		}
-	}
+	// Write the nai
+	naiBytes := make([]byte, 4)
+	binary.LittleEndian.PutUint32(naiBytes, nai)
+	b.Write(naiBytes)
 
 	return nil
 }

--- a/serializer_test.go
+++ b/serializer_test.go
@@ -109,3 +109,15 @@ func TestSerializeOpAccountUpdateOperation(t *testing.T) {
 		t.Error("Expected", expected, "got", got)
 	}
 }
+
+func TestSerializeOpTransfer(t *testing.T) {
+	got, _ := getTestTransferOp().SerializeOp()
+	expected := []byte{2, 10, 116, 105, 98, 102, 111, 120, 46, 118,
+		115, 99, 11, 118, 115, 99, 46, 103, 97, 116,
+		101, 119, 97, 121, 232, 3, 0, 0, 0, 0,
+		0, 0, 35, 32, 188, 190, 9, 116, 111, 61,
+		116, 105, 98, 102, 111, 120}
+	if !bytes.Equal(got, expected) {
+		t.Error("Expected", expected, "got", got)
+	}
+}

--- a/signer.go
+++ b/signer.go
@@ -50,9 +50,17 @@ func (h *HiveRpcNode) GetSigningData() (signingDataFromChain, error) {
 	return signingData, nil
 }
 
-func HashTxForSig(tx []byte) []byte {
+func HashTxForSig(tx []byte, chainID ...string) []byte {
 	var message bytes.Buffer
-	message.Write(getHiveChainId())
+
+	// Use custom chain ID if provided, otherwise use default
+	if len(chainID) > 0 && chainID[0] != "" {
+		cid, _ := hex.DecodeString(chainID[0])
+		message.Write(cid)
+	} else {
+		message.Write(getHiveChainId())
+	}
+
 	message.Write(tx)
 
 	digest := sha256.New()

--- a/testMocks.go
+++ b/testMocks.go
@@ -34,6 +34,17 @@ func getTestAccountUpdateOp() HiveOperation {
 	}
 }
 
+func getTestTransferOp() HiveOperation {
+	// legacy: 1d59a3a21cc704686a942c513658463fac61561a
+	// hf26: 2e40400aa62dc4b967e2c5b703a86f1e23ab4907
+	return TransferOperation{
+		To:     "vsc.gateway",
+		From:   "tibfox.vsc",
+		Memo:   "to=tibfox",
+		Amount: "1.000 HIVE",
+	}
+}
+
 func getTwoTestOps() []HiveOperation {
 	return []HiveOperation{getTestVoteOp(), getTestCustomJsonOp()}
 }


### PR DESCRIPTION
### Using custom chain ID with HiveTransaction:
```go
tx := HiveTransaction{
    // ... tx fields ...
}
sig, err := tx.Sign(keyPair, "123456789abcdef0000000000000000000000000000000000000000000000000") // Uses custom chain ID
```

### Using custom chain ID with HiveRpcNode:
```go
node := NewHiveRpcWithOpts([]string{"https://api.hive.blog"}, 1, 1)
node.ChainID = "fedcba9800000000000000000000000000000000000000000000000000000000"
txId, err := node.Broadcast(ops, &wif) // Uses HiveRpcNode's custom chain ID
```

### Using HashTxForSig directly:
```go
digest := HashTxForSig(message, "customChainIDHexString") // Uses custom chain ID
```