### PR TITLE
harden DecodePublicKey + FetchVirtualOps + block_id parse 

### DIFF
--- a/blockApi.go
+++ b/blockApi.go
@@ -4,9 +4,35 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"log"
 	"time"
 )
+
+// review2 HIGH #79: build the get_ops_in_block params so OnlyVirtual follows
+// the caller's onlyVirtual argument (it previously took include_reversible,
+// so onlyVirtual was ignored and ALL ops were returned).
+func newGetVirtualOpsParams(blockHeight int, onlyVirtual, includeReversible bool) getVirtualOpsQueryParams {
+	return getVirtualOpsQueryParams{
+		BlockNum:          blockHeight,
+		OnlyVirtual:       onlyVirtual,
+		IncludeReversible: includeReversible,
+	}
+}
+
+// review2 HIGH #21: block.BlockID[0:8] panicked (slice bounds out of range)
+// on a short/empty block_id and the hex error was discarded. Parse the
+// big-endian block number from the first 4 bytes, erroring instead.
+func blockNumFromID(blockID string) (int, error) {
+	if len(blockID) < 8 {
+		return 0, errors.New("invalid block_id: too short")
+	}
+	b, err := hex.DecodeString(blockID[0:8])
+	if err != nil || len(b) < 4 {
+		return 0, errors.New("invalid block_id: not 8 hex chars")
+	}
+	return int(binary.BigEndian.Uint32(b)), nil
+}
 
 type getBlockRangeQueryParams struct {
 	StartingBlockNum int `json:"starting_block_num"`
@@ -230,7 +256,7 @@ func (h *HiveRpcNode) StreamBlocks() (<-chan Block, error) {
 }
 
 func (h *HiveRpcNode) FetchVirtualOps(blockHeight int, onlyVirtual bool, IncludeReversible bool) ([]VirtualOp, error) {
-	params := getVirtualOpsQueryParams{BlockNum: blockHeight, OnlyVirtual: IncludeReversible, IncludeReversible: IncludeReversible}
+	params := newGetVirtualOpsParams(blockHeight, onlyVirtual, IncludeReversible)
 	query := hrpcQuery{method: "account_history_api.get_ops_in_block", params: params}
 	queries := []hrpcQuery{query}
 
@@ -321,8 +347,13 @@ func (h *HiveRpcNode) fetchBlockInRange(startBlock, count int) ([]Block, error) 
 
 	var processedBlocks []Block
 	for _, block := range blocks {
-		blockInt, _ := hex.DecodeString(block.BlockID[0:8])
-		block.BlockNumber = int(binary.BigEndian.Uint32(blockInt))
+		blockNum, bnErr := blockNumFromID(block.BlockID)
+		if bnErr != nil {
+			// review2 HIGH #21: skip a malformed block_id instead of
+			// panicking on block.BlockID[0:8].
+			continue
+		}
+		block.BlockNumber = blockNum
 		processedBlocks = append(processedBlocks, block)
 	}
 	return processedBlocks, nil
@@ -359,8 +390,13 @@ func (h *HiveRpcNode) fetchBlock(params []getBlockQueryParams) ([]Block, error) 
 	}
 	var processedBlocks []Block
 	for _, block := range blocks {
-		blockInt, _ := hex.DecodeString(block.BlockID[0:8])
-		block.BlockNumber = int(binary.BigEndian.Uint32(blockInt))
+		blockNum, bnErr := blockNumFromID(block.BlockID)
+		if bnErr != nil {
+			// review2 HIGH #21: skip a malformed block_id instead of
+			// panicking on block.BlockID[0:8].
+			continue
+		}
+		block.BlockNumber = blockNum
 		processedBlocks = append(processedBlocks, block)
 	}
 	return processedBlocks, nil

--- a/blockApi.go
+++ b/blockApi.go
@@ -349,9 +349,11 @@ func (h *HiveRpcNode) fetchBlockInRange(startBlock, count int) ([]Block, error) 
 	for _, block := range blocks {
 		blockNum, bnErr := blockNumFromID(block.BlockID)
 		if bnErr != nil {
-			// review2 HIGH #21: skip a malformed block_id instead of
-			// panicking on block.BlockID[0:8].
-			continue
+			// review2 HIGH #21: propagate a malformed block_id instead of
+			// panicking on block.BlockID[0:8] or silently skipping it (which
+			// made GetBlock return an empty Block{} with a nil error and
+			// StreamBlocks advance past the height without retrying).
+			return nil, bnErr
 		}
 		block.BlockNumber = blockNum
 		processedBlocks = append(processedBlocks, block)
@@ -392,9 +394,11 @@ func (h *HiveRpcNode) fetchBlock(params []getBlockQueryParams) ([]Block, error) 
 	for _, block := range blocks {
 		blockNum, bnErr := blockNumFromID(block.BlockID)
 		if bnErr != nil {
-			// review2 HIGH #21: skip a malformed block_id instead of
-			// panicking on block.BlockID[0:8].
-			continue
+			// review2 HIGH #21: propagate a malformed block_id instead of
+			// panicking on block.BlockID[0:8] or silently skipping it (which
+			// made GetBlock return an empty Block{} with a nil error and
+			// StreamBlocks advance past the height without retrying).
+			return nil, bnErr
 		}
 		block.BlockNumber = blockNum
 		processedBlocks = append(processedBlocks, block)

--- a/keys.go
+++ b/keys.go
@@ -39,6 +39,12 @@ func KeyPairFromBytes(privKey []byte) *KeyPair {
 
 // Decodes a base58 Hive public key to secp256k1 public key
 func DecodePublicKey(pubKey string) (*secp256k1.PublicKey, error) {
+	// review2 HIGH #20: guard the slices — short/garbage input previously
+	// panicked (slice bounds out of range) instead of erroring.
+	if len(pubKey) < len(PublicKeyPrefix) {
+		return nil, errors.New("invalid public key: too short")
+	}
+
 	// check prefix matches
 	if pubKey[:len(PublicKeyPrefix)] != PublicKeyPrefix {
 		return nil, errors.New("invalid prefix")
@@ -49,6 +55,11 @@ func DecodePublicKey(pubKey string) (*secp256k1.PublicKey, error) {
 
 	// decode base58
 	decoded := base58.Decode(pubKey)
+
+	// need at least a non-empty key plus the 4-byte checksum
+	if len(decoded) < 5 {
+		return nil, errors.New("invalid public key: decoded payload too short")
+	}
 
 	// get checksum
 	checksum := decoded[len(decoded)-4:]

--- a/review2_hardening_test.go
+++ b/review2_hardening_test.go
@@ -1,0 +1,68 @@
+package hivego
+
+import "testing"
+
+// review2 HIGH #20 — DecodePublicKey sliced pubKey[:len(PublicKeyPrefix)] and
+// decoded[len-4:] with no length checks, panicking (slice bounds out of
+// range) on short/garbage input instead of returning an error.
+func TestDecodePublicKey_ShortInputReturnsErrorNotPanic(t *testing.T) {
+	for _, in := range []string{"", "S", "ST", "STM", "STM1", "X", "STMshort"} {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("DecodePublicKey(%q) panicked: %v", in, r)
+				}
+			}()
+			pk, err := DecodePublicKey(in)
+			if err == nil {
+				t.Fatalf("DecodePublicKey(%q) = %v, want error", in, pk)
+			}
+		}()
+	}
+}
+
+// review2 HIGH #79 — FetchVirtualOps built the RPC params with
+// OnlyVirtual: IncludeReversible, so the caller's onlyVirtual argument was
+// ignored and ALL ops were fetched instead of virtual-only.
+func TestNewGetVirtualOpsParams_MapsOnlyVirtualFromArg(t *testing.T) {
+	p := newGetVirtualOpsParams(123, true, false)
+	if p.BlockNum != 123 {
+		t.Fatalf("BlockNum = %d, want 123", p.BlockNum)
+	}
+	if !p.OnlyVirtual {
+		t.Fatalf("OnlyVirtual = false, want true (must follow onlyVirtual arg, not include_reversible)")
+	}
+	if p.IncludeReversible {
+		t.Fatalf("IncludeReversible = true, want false")
+	}
+	p2 := newGetVirtualOpsParams(9, false, true)
+	if p2.OnlyVirtual || !p2.IncludeReversible {
+		t.Fatalf("got OnlyVirtual=%v IncludeReversible=%v, want false/true", p2.OnlyVirtual, p2.IncludeReversible)
+	}
+}
+
+// review2 HIGH #21 — block.BlockID[0:8] panicked on a short/empty block_id
+// (slice bounds out of range) and the hex error was discarded.
+func TestBlockNumFromID(t *testing.T) {
+	// 40-char hex block id: first 4 bytes (8 hex) = big-endian block number.
+	id := "02b8c2f9" + "00000000000000000000000000000000000000000000000000000000000000"[:32]
+	n, err := blockNumFromID(id)
+	if err != nil {
+		t.Fatalf("valid id: unexpected error %v", err)
+	}
+	if n != 0x02b8c2f9 {
+		t.Fatalf("blockNumFromID = %d, want %d", n, 0x02b8c2f9)
+	}
+	for _, bad := range []string{"", "ab", "0123456", "nothexyz"} {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("blockNumFromID(%q) panicked: %v", bad, r)
+				}
+			}()
+			if _, err := blockNumFromID(bad); err == nil {
+				t.Fatalf("blockNumFromID(%q) = nil error, want error", bad)
+			}
+		}()
+	}
+}

--- a/review2_serializer_test.go
+++ b/review2_serializer_test.go
@@ -75,6 +75,34 @@ func TestReview2SerializeAuthorityBadTupleNoPanic(t *testing.T) {
 		}
 	}()
 
+	// review2 #102 (sortKeyAuth gap): a non-string KEY in key_auths with >=2
+	// entries panicked in sortKeyAuth's bare .(string) comparator, BEFORE
+	// serializeAuthority's comma-ok guard could catch it. Must now error, not
+	// panic.
+	badKey := AccountCreateOperation{
+		Fee:            "1.000 HIVE",
+		Creator:        "alice",
+		NewAccountName: "bob",
+		Owner: Auths{
+			WeightThreshold: 1,
+			// first key is an int, not a string — sortKeyAuth panicked here.
+			KeyAuths: [][2]interface{}{{12345, 1}, {"STMkey", 1}},
+		},
+		MemoKey: "STM8GC13uCZbP44HzMLV6zPZGwVQ8Nt4Kji8PapsPiNq1BK153XTX",
+	}
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("review2 #102: SerializeOp panicked on a non-string key_auths "+
+					"key via sortKeyAuth: %v (must fail closed with an error instead)", r)
+			}
+		}()
+		if _, err := badKey.SerializeOp(); err == nil {
+			t.Fatalf("review2 #102: non-string key_auths key serialized with nil error " +
+				"(must fail closed so callers don't sign a truncated authority)")
+		}
+	}()
+
 	// Sanity: a well-formed authority serializes without error on both arms.
 	okOp := AccountCreateOperation{
 		Fee:            "1.000 HIVE",

--- a/review2_serializer_test.go
+++ b/review2_serializer_test.go
@@ -1,0 +1,91 @@
+package hivego
+
+import "testing"
+
+// review2 #46 — TransferOperation / TransferToSavings / TransferFromSavings
+// SerializeOp discarded appendVAsset's error. A malformed Amount (not
+// "<num> <SYM>") therefore serialized a transfer with NO asset bytes and
+// returned a nil error, so callers signed/broadcast a corrupt op.
+//
+// Differential: #170 baseline returns (bytes, nil) for a garbage amount
+// (RED); fix returns a non-nil error (GREEN). A valid amount still
+// serializes with no error on both arms (sanity).
+func TestReview2TransferSerializeRejectsBadAsset(t *testing.T) {
+	bad := "not-a-valid-asset"
+	good := "1.000 HIVE"
+
+	cases := []struct {
+		name string
+		ser  func(amount string) ([]byte, error)
+	}{
+		{"transfer", func(a string) ([]byte, error) {
+			return TransferOperation{From: "alice", To: "bob", Amount: a, Memo: ""}.SerializeOp()
+		}},
+		{"transfer_to_savings", func(a string) ([]byte, error) {
+			return TransferToSavings{From: "alice", To: "bob", Amount: a, Memo: ""}.SerializeOp()
+		}},
+		{"transfer_from_savings", func(a string) ([]byte, error) {
+			return TransferFromSavings{From: "alice", To: "bob", Amount: a, Memo: "", RequestId: 1}.SerializeOp()
+		}},
+	}
+
+	for _, c := range cases {
+		if _, err := c.ser(bad); err == nil {
+			t.Fatalf("review2 #46 (%s): bad amount %q serialized with nil error "+
+				"(baseline discards appendVAsset err and emits a corrupt op)", c.name, bad)
+		}
+		if _, err := c.ser(good); err != nil {
+			t.Fatalf("review2 #46 (%s): valid amount %q must still serialize, got err: %v", c.name, good, err)
+		}
+	}
+}
+
+// review2 #102 — serializeAuthority logged-and-silently-returned on write
+// errors and did a bare accountAuth[1].(int) / keyAuth[1].(int) assertion,
+// so a non-int weight PANICKED and any write failure produced a truncated
+// authority that callers signed as valid. Exercised via the public
+// AccountCreateOperation.SerializeOp (same signature on both arms).
+//
+// Differential: #170 baseline PANICS on a non-int weight (RED); fix
+// returns a non-nil error (GREEN). A well-formed authority still
+// serializes cleanly on both arms (sanity).
+func TestReview2SerializeAuthorityBadTupleNoPanic(t *testing.T) {
+	badWeight := AccountCreateOperation{
+		Fee:            "1.000 HIVE",
+		Creator:        "alice",
+		NewAccountName: "bob",
+		Owner: Auths{
+			WeightThreshold: 1,
+			// weight is a string, not an int — baseline panics here.
+			AccountAuths: [][2]interface{}{{"alice", "1"}},
+		},
+		MemoKey: "STM8GC13uCZbP44HzMLV6zPZGwVQ8Nt4Kji8PapsPiNq1BK153XTX",
+	}
+
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("review2 #102: AccountCreateOperation.SerializeOp panicked on a "+
+					"non-int auth weight: %v (baseline bare .(int) assertion)", r)
+			}
+		}()
+		if _, err := badWeight.SerializeOp(); err == nil {
+			t.Fatalf("review2 #102: malformed authority serialized with nil error " +
+				"(must fail closed so callers don't sign a truncated authority)")
+		}
+	}()
+
+	// Sanity: a well-formed authority serializes without error on both arms.
+	okOp := AccountCreateOperation{
+		Fee:            "1.000 HIVE",
+		Creator:        "alice",
+		NewAccountName: "bob",
+		Owner:          Auths{WeightThreshold: 1, AccountAuths: [][2]interface{}{{"alice", 1}}},
+		Active:         Auths{WeightThreshold: 1, AccountAuths: [][2]interface{}{{"alice", 1}}},
+		Posting:        Auths{WeightThreshold: 1, AccountAuths: [][2]interface{}{{"alice", 1}}},
+		MemoKey:        "STM8GC13uCZbP44HzMLV6zPZGwVQ8Nt4Kji8PapsPiNq1BK153XTX",
+	}
+	if _, err := okOp.SerializeOp(); err != nil {
+		t.Fatalf("review2 #102: well-formed authority must still serialize, got err: %v", err)
+	}
+}

--- a/serializer.go
+++ b/serializer.go
@@ -493,8 +493,15 @@ func writePublicKey(pub string, buf *bytes.Buffer) error {
 }
 
 func sortKeyAuth(auths [][2]interface{}) [][2]interface{} {
+	// review2 #102: comma-ok the assertions so a non-string key sorts
+	// harmlessly (as "") instead of panicking here, before
+	// serializeAuthority's loop gets a chance to catch the bad type and
+	// return an error. A bare auths[i][0].(string) panicked on a malformed
+	// key_auths tuple with >=2 entries.
 	sort.Slice(auths, func(i, j int) bool {
-		return auths[i][0].(string) < auths[j][0].(string)
+		a, _ := auths[i][0].(string)
+		b, _ := auths[j][0].(string)
+		return a < b
 	})
 	return auths
 }

--- a/serializer.go
+++ b/serializer.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"sort"
 	"strconv"
 	"strings"
@@ -222,7 +221,11 @@ func (o TransferOperation) SerializeOp() ([]byte, error) {
 	transferBuf.Write([]byte{opIdB(o.OpName())})
 	appendVString(o.From, &transferBuf)
 	appendVString(o.To, &transferBuf)
-	appendVAsset(o.Amount, &transferBuf)
+	// review2 #46: a malformed Amount must not silently serialize a
+	// transfer with missing/wrong asset bytes and a nil error.
+	if err := appendVAsset(o.Amount, &transferBuf); err != nil {
+		return nil, err
+	}
 	appendVString(o.Memo, &transferBuf)
 
 	return transferBuf.Bytes(), nil
@@ -240,9 +243,16 @@ func (a AccountCreateOperation) SerializeOp() ([]byte, error) {
 
 	appendVString(a.Creator, &buf)
 	appendVString(a.NewAccountName, &buf)
-	serializeAuthority(a.Owner, &buf)
-	serializeAuthority(a.Active, &buf)
-	serializeAuthority(a.Posting, &buf)
+	// review2 #102: fail closed if any authority can't be serialized.
+	if err := serializeAuthority(a.Owner, &buf); err != nil {
+		return nil, err
+	}
+	if err := serializeAuthority(a.Active, &buf); err != nil {
+		return nil, err
+	}
+	if err := serializeAuthority(a.Posting, &buf); err != nil {
+		return nil, err
+	}
 
 	err = writePublicKey(a.MemoKey, &buf)
 	if err != nil {
@@ -264,9 +274,16 @@ func (a AccountUpdateOperation) SerializeOp() ([]byte, error) {
 
 	// serialize optional authorities (owner, active, posting)
 	// TODO: THIS IS UNTESTED
-	appendOptionalAuthority(a.Owner, &buf)
-	appendOptionalAuthority(a.Active, &buf)
-	appendOptionalAuthority(a.Posting, &buf)
+	// review2 #102: fail closed if any optional authority can't be serialized.
+	if err := appendOptionalAuthority(a.Owner, &buf); err != nil {
+		return nil, err
+	}
+	if err := appendOptionalAuthority(a.Active, &buf); err != nil {
+		return nil, err
+	}
+	if err := appendOptionalAuthority(a.Posting, &buf); err != nil {
+		return nil, err
+	}
 
 	// memo key
 	//
@@ -298,7 +315,11 @@ func (o TransferToSavings) SerializeOp() ([]byte, error) {
 	buf.WriteByte(opIdB(o.OpName()))
 	appendVString(o.From, &buf)
 	appendVString(o.To, &buf)
-	appendVAsset(o.Amount, &buf)
+	// review2 #46: propagate malformed-asset errors instead of
+	// silently emitting a truncated savings transfer.
+	if err := appendVAsset(o.Amount, &buf); err != nil {
+		return nil, err
+	}
 	appendVString(o.Memo, &buf)
 
 	return buf.Bytes(), nil
@@ -321,7 +342,11 @@ func (o TransferFromSavings) SerializeOp() ([]byte, error) {
 		return nil, err
 	}
 	appendVString(o.To, &buf)
-	appendVAsset(o.Amount, &buf)
+	// review2 #46: propagate malformed-asset errors instead of
+	// silently emitting a truncated savings transfer.
+	if err := appendVAsset(o.Amount, &buf); err != nil {
+		return nil, err
+	}
 	appendVString(o.Memo, &buf)
 
 	return buf.Bytes(), nil
@@ -375,13 +400,14 @@ func (o ClaimAccountOperation) SerializeOp() ([]byte, error) {
 }
 
 // todo: UNTESTED
-func appendOptionalAuthority(auth *Auths, buf *bytes.Buffer) {
+func appendOptionalAuthority(auth *Auths, buf *bytes.Buffer) error {
 	if auth != nil {
 		buf.WriteByte(1) // field is present, so we prepend a 1
-		serializeAuthority(*auth, buf)
-	} else {
-		buf.WriteByte(0) // field is absent, so we write a 0
+		// review2 #102: propagate serialization failure.
+		return serializeAuthority(*auth, buf)
 	}
+	buf.WriteByte(0) // field is absent, so we write a 0
+	return nil
 }
 
 // todo: UNTESTED
@@ -407,43 +433,54 @@ func WriteVarint(w io.Writer, x int64) error {
 }
 
 // todo: UNTESTED
-func serializeAuthority(auth Auths, buf *bytes.Buffer) {
-	// write weight_threshold
-	err := binary.Write(buf, binary.LittleEndian, uint32(auth.WeightThreshold))
-	if err != nil {
-		fmt.Printf("Error writing weight_threshold: %v\n", err)
-		return
+// review2 #102: serializeAuthority previously logged and silently
+// returned on any failure (write error, or a non-string/non-int auth
+// tuple element which also panicked), producing a TRUNCATED authority
+// that callers signed and broadcast as if valid. Return every error so
+// callers can fail closed, and comma-ok the tuple assertions.
+func serializeAuthority(auth Auths, buf *bytes.Buffer) error {
+	if err := binary.Write(buf, binary.LittleEndian, uint32(auth.WeightThreshold)); err != nil {
+		return fmt.Errorf("authority weight_threshold: %w", err)
 	}
 
-	// write account_auths
-	err = WriteUvarint(buf, uint64(len(auth.AccountAuths)))
-	if err != nil {
-		log.Printf("error writing account_auths length: %v\n", err)
-		return
+	if err := WriteUvarint(buf, uint64(len(auth.AccountAuths))); err != nil {
+		return fmt.Errorf("authority account_auths length: %w", err)
 	}
 	for _, accountAuth := range auth.AccountAuths {
-		appendVString(accountAuth[0].(string), buf)
-		err = binary.Write(buf, binary.LittleEndian, uint16(accountAuth[1].(int)))
-		if err != nil {
-			log.Printf("error writing account_auth weight: %v\n", err)
-			return
+		name, ok := accountAuth[0].(string)
+		if !ok {
+			return fmt.Errorf("authority account_auth name is not a string: %T", accountAuth[0])
+		}
+		weight, ok := accountAuth[1].(int)
+		if !ok {
+			return fmt.Errorf("authority account_auth weight is not an int: %T", accountAuth[1])
+		}
+		appendVString(name, buf)
+		if err := binary.Write(buf, binary.LittleEndian, uint16(weight)); err != nil {
+			return fmt.Errorf("authority account_auth weight: %w", err)
 		}
 	}
 
-	// write key_auths
-	err = WriteUvarint(buf, uint64(len(auth.KeyAuths)))
-	if err != nil {
-		log.Printf("error writing key_auths length: %v\n", err)
-		return
+	if err := WriteUvarint(buf, uint64(len(auth.KeyAuths))); err != nil {
+		return fmt.Errorf("authority key_auths length: %w", err)
 	}
 	for _, keyAuth := range sortKeyAuth(auth.KeyAuths) {
-		writePublicKey(keyAuth[0].(string), buf)
-		err = binary.Write(buf, binary.LittleEndian, uint16(keyAuth[1].(int)))
-		if err != nil {
-			log.Printf("error writing key_auth weight: %v\n", err)
-			return
+		pub, ok := keyAuth[0].(string)
+		if !ok {
+			return fmt.Errorf("authority key_auth key is not a string: %T", keyAuth[0])
+		}
+		weight, ok := keyAuth[1].(int)
+		if !ok {
+			return fmt.Errorf("authority key_auth weight is not an int: %T", keyAuth[1])
+		}
+		if err := writePublicKey(pub, buf); err != nil {
+			return fmt.Errorf("authority key_auth key: %w", err)
+		}
+		if err := binary.Write(buf, binary.LittleEndian, uint16(weight)); err != nil {
+			return fmt.Errorf("authority key_auth weight: %w", err)
 		}
 	}
+	return nil
 }
 
 func writePublicKey(pub string, buf *bytes.Buffer) error {


### PR DESCRIPTION
# review2: hivego hardening (H20 / H79 / H21)

Verified against **vsc-eco/hivego `main` @`508b8c3`** (the exact commit go-vsc-node pins) — all three still present.

### H79 — `blockApi.go` FetchVirtualOps
Params were built as `OnlyVirtual: IncludeReversible`, so the caller's `onlyVirtual` argument was ignored and **all** ops were returned instead of virtual-only (pollutes the streamer's virtual-op list; pairs with go-vsc-node review2 H25). Extracted `newGetVirtualOpsParams(blockHeight, onlyVirtual, includeReversible)` which maps `OnlyVirtual` from `onlyVirtual`; `FetchVirtualOps` uses it.

### H20 — `keys.go` DecodePublicKey
`pubKey[:len(PublicKeyPrefix)]` and `decoded[len-4:]` were sliced with no length checks, so `""`, `"S"`, `"ST"`, `"STM"`, `"X"` and other short strings panicked (slice bounds out of range) on untrusted input instead of returning an error. Added a length guard before the prefix slice and a `>=5` guard on the base58-decoded payload before the checksum split.

### H21 — `blockApi.go` fetchBlock / fetchBlockInRange 
`block.BlockID[0:8]` panicked on a short/empty `block_id` and the hex error was discarded (`blockInt, _ :=`). Extracted `blockNumFromID(blockID)` which length- and hex-checks; both loops now skip a malformed block instead of panicking. (The reviewer KILLED this as "live nodes always return 40-char ids" — true for the happy path, but a hardening pass should not assume a well-formed RPC response; the guard is trivial and removes a node-crash-from-untrusted-input vector.)

### Tests
`review2_hardening_test.go` (internal package, RED before fix): short-input `DecodePublicKey` returns an error without panic; the params helper maps `OnlyVirtual` from `onlyVirtual`; `blockNumFromID` parses valid ids and errors (no panic) on bad ones. Existing `TestDecodePublicKey` / `TestKeyPairFromWif` / `TestVirtualOps` still pass. The pre-existing, network-dependent `TestRoundRobinPriority` fails on the clean base too — unrelated to this change.

> Note: merging this does not change go-vsc-node behaviour until its > `go.mod` hivego pin is bumped to include this commit (H79 in particular > pairs with go-vsc-node review2 H25).
