### PR TITLE
 review7 hivego MEDs — serialization/parse hardening

### DIFF
--- a/audit_review7_med_test.go
+++ b/audit_review7_med_test.go
@@ -39,20 +39,37 @@ func TestAuditReview7_HGM9_Base58RoundTrip(t *testing.T) {
 }
 
 // HG-M10: opIdB must fail loudly on an unregistered op instead of returning 0
-// (vote_operation) and silently mis-serializing it.
+// (vote_operation) and silently mis-serializing it. Resolved as a returned
+// error (not a panic) so SerializeOp callers can fail closed.
 func TestAuditReview7_HGM10_UnknownOpFailsLoud(t *testing.T) {
-	if opIdB("vote") != 0 {
-		t.Error("HG-M10: vote must remain op id 0")
+	if id, err := opIdB("vote"); err != nil || id != 0 {
+		t.Errorf("HG-M10: vote must remain op id 0, got id=%d err=%v", id, err)
 	}
-	if got := opIdB("custom_json"); got == 0 {
-		t.Error("HG-M10: a known non-vote op must not collide with vote (0)")
+	if id, err := opIdB("custom_json"); err != nil || id == 0 {
+		t.Errorf("HG-M10: a known non-vote op must not collide with vote (0), got id=%d err=%v", id, err)
 	}
-	defer func() {
-		if recover() == nil {
-			t.Error("HG-M10: an unregistered op must panic, not map to vote (0)")
-		}
-	}()
-	_ = opIdB("definitely_not_a_real_op")
+	if _, err := opIdB("definitely_not_a_real_op"); err == nil {
+		t.Error("HG-M10: an unregistered op must error, not map to vote (0)")
+	}
+}
+
+// HG-M10 (follow-up): a directly-constructed ClaimRewardOperation has an empty
+// opText; now that OpName returns the registered literal, it must serialize
+// cleanly (op id 39) instead of failing/panicking as an "unknown operation".
+func TestAuditReview7_HGM10_ClaimRewardDirectConstruct(t *testing.T) {
+	op := ClaimRewardOperation{
+		Account:     "alice",
+		RewardHBD:   "0.000 HBD",
+		RewardHIVE:  "0.000 HIVE",
+		RewardVests: "0.000000 VESTS",
+	}
+	b, err := op.SerializeOp()
+	if err != nil {
+		t.Fatalf("HG-M10: directly-constructed ClaimRewardOperation must serialize, got err: %v", err)
+	}
+	if len(b) == 0 || b[0] != 39 {
+		t.Fatalf("HG-M10: claim_reward_balance op id must be 39, got first byte %v", b)
+	}
 }
 
 // HG-M11: a short/empty block_id must not panic the BlockID[0:8] slice.

--- a/audit_review7_med_test.go
+++ b/audit_review7_med_test.go
@@ -1,0 +1,107 @@
+package hivego
+
+// review7 hivego MED fixes (pure-MED; CRIT/HIGH-dual-labeled ones excluded).
+
+import (
+	"bytes"
+	"testing"
+	"time"
+)
+
+// HG-M8: appendVAsset must reject a negative amount instead of serializing it
+// as a two's-complement int64 (which reads back as a huge positive on Hive).
+func TestAuditReview7_HGM8_RejectsNegativeAmount(t *testing.T) {
+	var neg bytes.Buffer
+	if err := appendVAsset("-5.000 HIVE", &neg); err == nil {
+		t.Error("HG-M8: negative amount must be rejected")
+	}
+	var ok bytes.Buffer
+	if err := appendVAsset("5.000 HIVE", &ok); err != nil {
+		t.Errorf("HG-M8: a valid amount must still serialize: %v", err)
+	}
+}
+
+// HG-M9: GphBase58Encode must include the version byte so the encode/decode
+// pair round-trips.
+func TestAuditReview7_HGM9_Base58RoundTrip(t *testing.T) {
+	input := []byte{0x01, 0x02, 0x03, 0x04, 0x05}
+	version := [1]byte{0x80}
+	payload, gotVersion, err := GphBase58CheckDecode(GphBase58Encode(input, version))
+	if err != nil {
+		t.Fatalf("HG-M9: round-trip decode failed: %v", err)
+	}
+	if gotVersion != version {
+		t.Errorf("HG-M9: version mismatch: got %v want %v", gotVersion, version)
+	}
+	if !bytes.Equal(payload, input) {
+		t.Errorf("HG-M9: payload mismatch: got %v want %v", payload, input)
+	}
+}
+
+// HG-M10: opIdB must fail loudly on an unregistered op instead of returning 0
+// (vote_operation) and silently mis-serializing it.
+func TestAuditReview7_HGM10_UnknownOpFailsLoud(t *testing.T) {
+	if opIdB("vote") != 0 {
+		t.Error("HG-M10: vote must remain op id 0")
+	}
+	if got := opIdB("custom_json"); got == 0 {
+		t.Error("HG-M10: a known non-vote op must not collide with vote (0)")
+	}
+	defer func() {
+		if recover() == nil {
+			t.Error("HG-M10: an unregistered op must panic, not map to vote (0)")
+		}
+	}()
+	_ = opIdB("definitely_not_a_real_op")
+}
+
+// HG-M11: a short/empty block_id must not panic the BlockID[0:8] slice.
+// Resolved against main's review2 #21 fix: blockNumFromID returns an explicit
+// error on malformed input rather than silently yielding 0.
+func TestAuditReview7_HGM11_ShortBlockID(t *testing.T) {
+	if _, err := blockNumFromID(""); err == nil {
+		t.Error("HG-M11: empty id must error, not panic")
+	}
+	if _, err := blockNumFromID("abc"); err == nil {
+		t.Error("HG-M11: short id must error, not panic")
+	}
+	if got, err := blockNumFromID("0000000a1234567890"); err != nil || got != 10 {
+		t.Errorf("HG-M11: '0000000a...' -> %d, err %v, want 10, nil", got, err)
+	}
+}
+
+// HG-M14: appendVStringArray must use a varint length prefix (graphene vector),
+// not a single byte that wraps at 256 / is invalid at >= 128.
+func TestAuditReview7_HGM14_ArrayVarintLength(t *testing.T) {
+	// < 128: varint is the identical single byte.
+	var small bytes.Buffer
+	appendVStringArray([]string{"a", "b"}, &small)
+	if small.Bytes()[0] != 2 {
+		t.Errorf("HG-M14: small array prefix = %d, want 2", small.Bytes()[0])
+	}
+	// 200 entries: varint(200) = 0xC8 0x01 (two bytes), not a single 0xC8.
+	big := make([]string, 200)
+	for i := range big {
+		big[i] = "x"
+	}
+	var b bytes.Buffer
+	appendVStringArray(big, &b)
+	out := b.Bytes()
+	if out[0] != 0xC8 || out[1] != 0x01 {
+		t.Errorf("HG-M14: prefix for 200 entries = %x %x, want c8 01 (varint)", out[0], out[1])
+	}
+}
+
+// HG-M16: ValidateExpiration rejects an expired/malformed tx; accepts a future one.
+func TestAuditReview7_HGM16_ValidateExpiration(t *testing.T) {
+	now := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
+	if (&HiveTransaction{Expiration: "2016-08-08T12:24:17"}).ValidateExpiration(now) == nil {
+		t.Error("HG-M16: an expired tx must be rejected")
+	}
+	if (&HiveTransaction{Expiration: "not-a-date"}).ValidateExpiration(now) == nil {
+		t.Error("HG-M16: a malformed expiration must be rejected")
+	}
+	if err := (&HiveTransaction{Expiration: "2030-01-01T00:00:00"}).ValidateExpiration(now); err != nil {
+		t.Errorf("HG-M16: a future tx must validate: %v", err)
+	}
+}

--- a/blockApi.go
+++ b/blockApi.go
@@ -20,9 +20,9 @@ func newGetVirtualOpsParams(blockHeight int, onlyVirtual, includeReversible bool
 	}
 }
 
-// review2 HIGH #21: block.BlockID[0:8] panicked (slice bounds out of range)
-// on a short/empty block_id and the hex error was discarded. Parse the
-// big-endian block number from the first 4 bytes, erroring instead.
+// review2 HIGH #21 / review7 HG-M11: block.BlockID[0:8] panicked (slice bounds
+// out of range) on a short/empty block_id and the hex error was discarded.
+// Parse the big-endian block number from the first 4 bytes, erroring instead.
 func blockNumFromID(blockID string) (int, error) {
 	if len(blockID) < 8 {
 		return 0, errors.New("invalid block_id: too short")
@@ -349,9 +349,9 @@ func (h *HiveRpcNode) fetchBlockInRange(startBlock, count int) ([]Block, error) 
 	for _, block := range blocks {
 		blockNum, bnErr := blockNumFromID(block.BlockID)
 		if bnErr != nil {
-			// review2 HIGH #21: propagate a malformed block_id instead of
-			// panicking on block.BlockID[0:8] or silently skipping it (which
-			// made GetBlock return an empty Block{} with a nil error and
+			// review2 HIGH #21 / review7 HG-M11: propagate a malformed block_id
+			// instead of panicking on block.BlockID[0:8] or silently skipping it
+			// (which made GetBlock return an empty Block{} with a nil error and
 			// StreamBlocks advance past the height without retrying).
 			return nil, bnErr
 		}
@@ -394,9 +394,9 @@ func (h *HiveRpcNode) fetchBlock(params []getBlockQueryParams) ([]Block, error) 
 	for _, block := range blocks {
 		blockNum, bnErr := blockNumFromID(block.BlockID)
 		if bnErr != nil {
-			// review2 HIGH #21: propagate a malformed block_id instead of
-			// panicking on block.BlockID[0:8] or silently skipping it (which
-			// made GetBlock return an empty Block{} with a nil error and
+			// review2 HIGH #21 / review7 HG-M11: propagate a malformed block_id
+			// instead of panicking on block.BlockID[0:8] or silently skipping it
+			// (which made GetBlock return an empty Block{} with a nil error and
 			// StreamBlocks advance past the height without retrying).
 			return nil, bnErr
 		}

--- a/broadcaster.go
+++ b/broadcaster.go
@@ -3,6 +3,7 @@ package hivego
 import (
 	"encoding/hex"
 	"fmt"
+	"time"
 
 	"github.com/decred/dcrd/dcrec/secp256k1/v2"
 )
@@ -25,6 +26,28 @@ func (t *HiveTransaction) GenerateTrxId() (string, error) {
 	digest := HashTx(tB)
 
 	return hex.EncodeToString(digest)[0:40], nil
+}
+
+// ValidateExpiration reports an error if the transaction's Expiration is
+// malformed or not strictly in the future relative to `now` (compared in UTC,
+// the timezone Hive uses for the expiration field).
+//
+// review7 HG-M16: Sign() is a pure signing primitive and is deliberately left
+// time-independent — a tx must be re-signable/reproducible (fixed-vector tests
+// sign a tx dated 2016), so Sign() cannot reject an expired tx without breaking
+// deterministic signing. Callers that build a tx for broadcast should call
+// ValidateExpiration(time.Now().UTC()) first, so they don't sign and broadcast
+// a tx the node will only reject as expired.
+func (t *HiveTransaction) ValidateExpiration(now time.Time) error {
+	exp, err := time.Parse("2006-01-02T15:04:05", t.Expiration)
+	if err != nil {
+		return fmt.Errorf("invalid expiration %q: %w", t.Expiration, err)
+	}
+	if !exp.After(now.UTC()) {
+		return fmt.Errorf("transaction expiration %s is not in the future (now %s)",
+			t.Expiration, now.UTC().Format("2006-01-02T15:04:05"))
+	}
+	return nil
 }
 
 func (t *HiveTransaction) Sign(keyPair KeyPair, chainId ...string) (string, error) {

--- a/hive_ops.go
+++ b/hive_ops.go
@@ -164,7 +164,11 @@ type ClaimRewardOperation struct {
 }
 
 func (o ClaimRewardOperation) OpName() string {
-	return o.opText
+	// review7 HG-M10: return the registered literal (like every other op)
+	// instead of the unexported opText, which was empty on a directly
+	// constructed ClaimRewardOperation and made SerializeOp fail as an
+	// "unknown operation".
+	return "claim_reward_balance"
 }
 
 type ClaimAccountOperation struct {

--- a/hive_ops.go
+++ b/hive_ops.go
@@ -215,10 +215,15 @@ func getHiveChainId() []byte {
 	return cid
 }
 
-func getHiveOpId(op string) uint64 {
+// getHiveOpId returns the graphene operation id for op and whether op is a
+// registered operation. review7 HG-M10: it used to return the map zero-value
+// (0 == vote_operation) for an unregistered op, so opIdB silently serialized an
+// unknown op as a vote.
+func getHiveOpId(op string) (uint64, bool) {
 	op = op + "_operation"
 	hiveOpsIds := getHiveOpIds()
-	return hiveOpsIds[op]
+	id, ok := hiveOpsIds[op]
+	return id, ok
 }
 
 func getHiveOpIds() map[string]uint64 {

--- a/serializer.go
+++ b/serializer.go
@@ -12,18 +12,29 @@ import (
 	"time"
 )
 
-func opIdB(opName string) byte {
+func opIdB(opName string) (byte, error) {
 	id, ok := getHiveOpId(opName)
 	if !ok {
 		// review7 HG-M10: an unregistered op name previously mapped to 0 ==
 		// vote_operation, silently mis-serializing the op as a vote inside an
-		// otherwise-valid (and then signed) transaction. Every HiveOperation's
-		// OpName must be registered in getHiveOpIds, so an unknown op is a
-		// programmer error — fail loudly instead of producing a wrong-but-signed
-		// transaction.
-		panic("hivego: unknown operation type (not registered in getHiveOpIds): " + opName)
+		// otherwise-valid (and then signed) transaction. Return an error so the
+		// caller's SerializeOp fails closed instead of emitting a
+		// wrong-but-signed op.
+		return 0, fmt.Errorf("hivego: unknown operation type (not registered in getHiveOpIds): %q", opName)
 	}
-	return byte(id)
+	return byte(id), nil
+}
+
+// writeOpId resolves the operation id for opName and writes it to buf,
+// returning an error for an unregistered op (review7 HG-M10) so the caller's
+// SerializeOp fails closed instead of emitting a wrong-but-signed op.
+func writeOpId(opName string, buf *bytes.Buffer) error {
+	id, err := opIdB(opName)
+	if err != nil {
+		return err
+	}
+	buf.WriteByte(id)
+	return nil
 }
 
 func refBlockNumB(refBlockNumber uint16) []byte {
@@ -193,7 +204,9 @@ func serializeOps(ops []HiveOperation) ([]byte, error) {
 
 func (o voteOperation) SerializeOp() ([]byte, error) {
 	var voteBuf bytes.Buffer
-	voteBuf.Write([]byte{opIdB(o.OpName())})
+	if err := writeOpId(o.OpName(), &voteBuf); err != nil {
+		return nil, err
+	}
 	appendVString(o.Voter, &voteBuf)
 	appendVString(o.Author, &voteBuf)
 	appendVString(o.Permlink, &voteBuf)
@@ -207,7 +220,9 @@ func (o voteOperation) SerializeOp() ([]byte, error) {
 
 func (o CustomJsonOperation) SerializeOp() ([]byte, error) {
 	var jBuf bytes.Buffer
-	jBuf.Write([]byte{opIdB(o.OpName())})
+	if err := writeOpId(o.OpName(), &jBuf); err != nil {
+		return nil, err
+	}
 	appendVStringArray(o.RequiredAuths, &jBuf)
 	appendVStringArray(o.RequiredPostingAuths, &jBuf)
 	appendVString(o.Id, &jBuf)
@@ -218,7 +233,9 @@ func (o CustomJsonOperation) SerializeOp() ([]byte, error) {
 
 func (o ClaimRewardOperation) SerializeOp() ([]byte, error) {
 	var claimBuf bytes.Buffer
-	claimBuf.Write([]byte{opIdB(o.OpName())})
+	if err := writeOpId(o.OpName(), &claimBuf); err != nil {
+		return nil, err
+	}
 	appendVString(o.Account, &claimBuf)
 	err := appendVAsset(o.RewardHIVE, &claimBuf)
 
@@ -243,7 +260,9 @@ func (o ClaimRewardOperation) SerializeOp() ([]byte, error) {
 
 func (o TransferOperation) SerializeOp() ([]byte, error) {
 	var transferBuf bytes.Buffer
-	transferBuf.Write([]byte{opIdB(o.OpName())})
+	if err := writeOpId(o.OpName(), &transferBuf); err != nil {
+		return nil, err
+	}
 	appendVString(o.From, &transferBuf)
 	appendVString(o.To, &transferBuf)
 	// review2 #46: a malformed Amount must not silently serialize a
@@ -258,7 +277,9 @@ func (o TransferOperation) SerializeOp() ([]byte, error) {
 
 func (a AccountCreateOperation) SerializeOp() ([]byte, error) {
 	var buf bytes.Buffer
-	buf.WriteByte(opIdB(a.OpName()))
+	if err := writeOpId(a.OpName(), &buf); err != nil {
+		return nil, err
+	}
 
 	// fee
 	err := appendVAsset(a.Fee, &buf)
@@ -292,7 +313,9 @@ func (a AccountUpdateOperation) SerializeOp() ([]byte, error) {
 	var buf bytes.Buffer
 
 	// operation ID
-	buf.WriteByte(opIdB(a.OpName()))
+	if err := writeOpId(a.OpName(), &buf); err != nil {
+		return nil, err
+	}
 
 	// account name
 	appendVString(a.Account, &buf)
@@ -337,7 +360,9 @@ func (o TransferToSavings) SerializeOp() ([]byte, error) {
 	//   ])
 
 	var buf bytes.Buffer
-	buf.WriteByte(opIdB(o.OpName()))
+	if err := writeOpId(o.OpName(), &buf); err != nil {
+		return nil, err
+	}
 	appendVString(o.From, &buf)
 	appendVString(o.To, &buf)
 	// review2 #46: propagate malformed-asset errors instead of
@@ -360,7 +385,9 @@ func (o TransferFromSavings) SerializeOp() ([]byte, error) {
 	//   ])
 
 	var buf bytes.Buffer
-	buf.WriteByte(opIdB(o.OpName()))
+	if err := writeOpId(o.OpName(), &buf); err != nil {
+		return nil, err
+	}
 	appendVString(o.From, &buf)
 	err := binary.Write(&buf, binary.LittleEndian, uint32(o.RequestId))
 	if err != nil {
@@ -387,7 +414,9 @@ func (o CancelTransferFromSavings) SerializeOp() ([]byte, error) {
 	//   )
 
 	var buf bytes.Buffer
-	buf.WriteByte(opIdB(o.OpName()))
+	if err := writeOpId(o.OpName(), &buf); err != nil {
+		return nil, err
+	}
 	appendVString(o.From, &buf)
 	err := binary.Write(&buf, binary.LittleEndian, uint32(o.RequestId))
 	if err != nil {
@@ -399,7 +428,9 @@ func (o CancelTransferFromSavings) SerializeOp() ([]byte, error) {
 
 func (o TransferToVesting) SerializeOp() ([]byte, error) {
 	var buf bytes.Buffer
-	buf.WriteByte(opIdB(o.OpName()))
+	if err := writeOpId(o.OpName(), &buf); err != nil {
+		return nil, err
+	}
 	appendVString(o.From, &buf)
 	appendVString(o.To, &buf)
 	err := appendVAsset(o.Amount, &buf)
@@ -412,7 +443,9 @@ func (o TransferToVesting) SerializeOp() ([]byte, error) {
 
 func (o ClaimAccountOperation) SerializeOp() ([]byte, error) {
 	var buf bytes.Buffer
-	buf.WriteByte(opIdB(o.OpName()))
+	if err := writeOpId(o.OpName(), &buf); err != nil {
+		return nil, err
+	}
 
 	appendVString(o.Creator, &buf)
 	err := appendVAsset(o.Fee, &buf)

--- a/serializer.go
+++ b/serializer.go
@@ -13,7 +13,16 @@ import (
 )
 
 func opIdB(opName string) byte {
-	id := getHiveOpId(opName)
+	id, ok := getHiveOpId(opName)
+	if !ok {
+		// review7 HG-M10: an unregistered op name previously mapped to 0 ==
+		// vote_operation, silently mis-serializing the op as a vote inside an
+		// otherwise-valid (and then signed) transaction. Every HiveOperation's
+		// OpName must be registered in getHiveOpIds, so an unknown op is a
+		// programmer error — fail loudly instead of producing a wrong-but-signed
+		// transaction.
+		panic("hivego: unknown operation type (not registered in getHiveOpIds): " + opName)
+	}
 	return byte(id)
 }
 
@@ -61,7 +70,15 @@ func appendVString(s string, b *bytes.Buffer) *bytes.Buffer {
 }
 
 func appendVStringArray(a []string, b *bytes.Buffer) *bytes.Buffer {
-	b.Write([]byte{byte(len(a))})
+	// review7 HG-M14: graphene vector lengths are unsigned varints (same as
+	// appendVString / countOpsB), not a single byte. The old `byte(len(a))`
+	// truncated at 256 (wrapping to a 0 prefix) and already produced an invalid
+	// prefix for any array >= 128 entries — e.g. a multisig custom_json with
+	// many required_auths. For < 128 entries the varint is the identical single
+	// byte, so well-formed small arrays are unchanged.
+	vBuf := make([]byte, 5)
+	vLen := binary.PutUvarint(vBuf, uint64(len(a)))
+	b.Write(vBuf[0:vLen])
 	for _, s := range a {
 		appendVString(s, b)
 	}
@@ -118,6 +135,14 @@ func appendVAsset(asset string, b *bytes.Buffer) error {
 	amount, err := strconv.ParseInt(fullNumber, 10, 64)
 	if err != nil {
 		return err
+	}
+
+	// review7 HG-M8: ParseInt accepts a negative value, which would serialize
+	// as a two's-complement int64 — an asset amount is unsigned on Hive, so a
+	// negative would be read as a huge positive (e.g. -5000 -> 78ecffff...).
+	// Reject it instead of producing a malformed signed transfer.
+	if amount < 0 {
+		return errors.New("asset amount must be non-negative: " + asset)
 	}
 
 	// Write the amount as int64

--- a/serializer_test.go
+++ b/serializer_test.go
@@ -6,9 +6,12 @@ import (
 )
 
 func TestOpIdB(t *testing.T) {
-	got := opIdB("custom_json")
+	got, err := opIdB("custom_json")
 	expected := byte(18)
 
+	if err != nil {
+		t.Fatal("unexpected error:", err)
+	}
 	if got != expected {
 		t.Error("Expected", expected, "got")
 	}

--- a/signer.go
+++ b/signer.go
@@ -104,8 +104,15 @@ func GphBase58CheckDecode(input string) ([]byte, [1]byte, error) {
 }
 
 func GphBase58Encode(input []byte, version [1]byte) string {
-	checksum := checksum(append([]byte{version[0]}, input...))
-	encoded := append(input, checksum[:4]...)
+	// review7 HG-M9: the version byte must be part of the encoded output, not
+	// just the checksum pre-image — GphBase58CheckDecode reads decoded[0] as the
+	// version and re-derives the checksum over (version || payload). The old
+	// form emitted base58(input || checksum), dropping the version prefix, so a
+	// GphBase58CheckDecode round-trip mis-read the first payload byte as the
+	// version and failed the checksum.
+	payload := append([]byte{version[0]}, input...)
+	checksum := checksum(payload)
+	encoded := append(payload, checksum[:4]...)
 	return base58.Encode(encoded)
 }
 


### PR DESCRIPTION
This pull request addresses several medium-severity (MED) audit issues in the HiveGo codebase, focusing on serialization correctness, error handling, and transaction validation. The changes improve the robustness of asset handling, block ID parsing, operation serialization, array encoding, and transaction expiration checks. Unit tests have been added to verify all fixes.

**Serialization and Encoding Improvements:**

- `appendVAsset` now rejects negative asset amounts, preventing them from being serialized as large positive values due to two's-complement representation.
- `appendVStringArray` now uses a varint length prefix for arrays, conforming to the Graphene protocol and supporting arrays larger than 127 elements without invalid encoding.
- `GphBase58Encode` now correctly includes the version byte in the encoded output, ensuring round-trip compatibility with `GphBase58CheckDecode`.

**Error Handling and Validation:**

- `opIdB` now panics if an unknown operation name is provided, instead of silently mapping it to the vote operation (id 0), preventing accidental mis-serialization of unknown operations. [[1]](diffhunk://#diff-22539312577827eab0e99fb7e9900862f9443f612faada937179ade1652346e2L17-R26) [[2]](diffhunk://#diff-61e6e3982e770d86a6ce88258f7c0be8c5f12a08e9c3c1fb2e3750e98586e6a0L218-R226)
- `blockNumberFromID` safely parses block numbers from block IDs, returning 0 for malformed or too-short IDs instead of panicking. This is now used throughout block processing. [[1]](diffhunk://#diff-bd20c284ffe6b5f6ed5cb495a83d08157e1b4ff614bca2db062d23fdd51096dcR11-R27) [[2]](diffhunk://#diff-bd20c284ffe6b5f6ed5cb495a83d08157e1b4ff614bca2db062d23fdd51096dcL324-R343) [[3]](diffhunk://#diff-bd20c284ffe6b5f6ed5cb495a83d08157e1b4ff614bca2db062d23fdd51096dcL362-R380)
- `HiveTransaction.ValidateExpiration` checks that a transaction's expiration is a valid timestamp and strictly in the future, helping callers avoid signing or broadcasting expired transactions.

**API Parameter Correction:**

- `FetchVirtualOps` now correctly forwards the `onlyVirtual` parameter, fixing a bug where it was previously ignored in favor of another variable.

**Testing:**

- Comprehensive unit tests have been added in `audit_review7_med_test.go` to verify all the above fixes, including edge cases and error conditions.